### PR TITLE
Testing with unsharded inputs

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -164,6 +164,7 @@ void unshard(TensorView* tv) {
       id->parallelize(ParallelType::Serial);
     }
   }
+  tv->setDeviceMesh({});
 }
 
 void unshard(Fusion* fusion) {

--- a/test/multidevice.cpp
+++ b/test/multidevice.cpp
@@ -147,17 +147,6 @@ void PipelineTest::validate() {
     auto obtained_output = outputs.at(i);
     GTEST_EXPECT_TRUE(torch::allclose(ref_output, obtained_output)) << "Device " << communicator->deviceId() << " has unexpected output " << i << " corresponding to tv " << output_tv << ". Expected values: " << ref_output << ", obtained values: " << obtained_output;
   }
-  GTEST_ASSERT_EQ(ref_unsharded_outputs.size(), outputs.size());
-  for (int i : c10::irange(runtime->fusion()->outputs().size())) {
-    GTEST_ASSERT_TRUE(runtime->fusion()->outputs().at(i)->isA<TensorView>());
-    auto output_tv = runtime->fusion()->outputs().at(i)->as<TensorView>();
-    if (!output_tv->getDeviceMesh().has(communicator->deviceId())) {
-      continue;
-    }
-    auto ref_output = shardTensor(ref_unsharded_outputs.at(i), output_tv->getDeviceMesh(), communicator->deviceId());
-    auto obtained_output = outputs.at(i);
-    GTEST_EXPECT_TRUE(torch::allclose(ref_output, obtained_output)) << "Device " << communicator->deviceId() << " has unexpected output " << i <<", expected: " << ref_output << ", obtained: " << obtained_output;
-  }
 }
 
 // Run and validate a pipeline

--- a/test/multidevice.cpp
+++ b/test/multidevice.cpp
@@ -111,202 +111,81 @@ void CommunicationTest::resetDstBuffers() {
   }
 }
 
-namespace {
-
-void doSendRecv(
-    DeviceIdxType sender,
-    DeviceIdxType receiver,
-    at::Tensor send_buf,
-    at::Tensor recv_buf,
-    Communicator* communicator) {
-  CommParams params;
-  params.root = sender;
-  if (sender == receiver) {
-    params.team = {sender};
-  } else {
-    params.team = {sender, receiver};
-  }
-  if (send_buf.numel()) {
-    params.src_bufs = {send_buf};
-  }
-  if (recv_buf.numel()) {
-    params.dst_bufs = {recv_buf};
-  }
-  auto work = SendRecv(params).post(*communicator);
-  if (work) {
-    work->wait();
-  }
-}
-
-// Send a possibly sharded tensor to one "tester" device
-void SendToTester(
-    TensorView* tv,
-    at::Tensor tensor,
-    at::Tensor tester_tensor,
-    DeviceIdxType tester,
-    Communicator* communicator,
-    bool debug_print) {
-  auto mesh = tv->getDeviceMesh();
-  if (isSharded(tv)) {
-    for (DeviceIdxType j : c10::irange(mesh.vector().size())) {
-      at::Tensor send_buf, recv_buf;
-      auto sender = mesh.vector().at(j);
-      if (communicator->deviceId() == sender ||
-          communicator->deviceId() == tester) {
-        if (communicator->deviceId() == sender) {
-          send_buf = tensor.index({0, "..."});
-        }
-        if (communicator->deviceId() == tester) {
-          recv_buf = tester_tensor.index({j, "..."});
-        }
-        doSendRecv(sender, tester, send_buf, recv_buf, communicator);
-      }
-    }
-  } else {
-    at::Tensor send_buf, recv_buf;
-    auto sender = mesh.vector().at(0);
-    if (communicator->deviceId() == sender ||
-        communicator->deviceId() == tester) {
-      if (communicator->deviceId() == sender) {
-        send_buf = tensor;
-      }
-      if (communicator->deviceId() == tester) {
-        recv_buf = tester_tensor;
-      }
-      doSendRecv(sender, tester, send_buf, recv_buf, communicator);
-    }
-  }
-}
-
-c10::IValue allocate_unsharded_input(
-    DeviceIdxType tester,
-    TensorView* tv,
-    at::Tensor sharded_input) {
-  // TODO: Extend to multi-dimension mesh
-  std::vector<int64_t> unsharded_sizes;
-  for (size_t i = 0; i < tv->nDims(); i++) {
-    if (tv->axis(i)->isDeviceDim()) {
-      unsharded_sizes.push_back(tv->getDeviceMesh().vector().size());
-    } else {
-      unsharded_sizes.push_back(sharded_input.size(i));
-    }
-  }
-  at::Tensor unsharded_input =
-      at::rand(unsharded_sizes, sharded_input.options());
-  unsharded_input.index_put_({tester, "..."}, sharded_input.index({0, "..."}));
-  return unsharded_input;
-}
-} // namespace
-
 // Utility function used for validation in the tests
 // It compares the given (possibly sharded) output with the result of the Fusion
 // run on a single device with the given (possibly sharded) inputs
-void PipelineTest::validate(DeviceIdxType tester, bool auto_schedule) {
-  recordEvent("gather inputs at tester");
-  // gathering all the inputs at tester
-  std::vector<c10::IValue> unsharded_inputs;
-  for (auto i : c10::irange(inputs.size())) {
-    TensorView* tv = runtime->fusion()->inputs().at(i)->as<TensorView>();
-    c10::IValue unsharded_input = isSharded(tv)
-        ? allocate_unsharded_input(tester, tv, inputs.at(i).toTensor())
-        : inputs.at(i).deepcopy();
-    unsharded_inputs.push_back(unsharded_input);
+void PipelineTest::validate() {
+  // execute the fusion on one device without pipeline scheduling
+  auto fusion_copy = std::make_unique<Fusion>(*runtime->fusion());
+  unshard(fusion_copy.get());
+  FusionExecutorCache unsharded_fec (std::move(fusion_copy));
+  recordEvent("run unsharded fusion");
+  auto ref_unsharded_outputs = unsharded_fec.runFusionWithInputs(unsharded_inputs);
 
-    SendToTester(
-        tv,
-        inputs.at(i).toTensor(),
-        unsharded_inputs.at(i).toTensor(),
-        tester,
-        runtime->comm(),
-        debug_print);
+  if (debug_print) {
+    std::stringstream ss;
+    std::string indent = "  ";
+    ss << "Device " << communicator->deviceId() << "'s expected (unsharded) outputs:{\n";
+    for (auto& t : ref_unsharded_outputs) {
+      ss << indent << t;
+    }
+    ss << "\n}";
+    std::cout << ss.str() << std::endl;
   }
 
-  std::unique_ptr<FusionExecutorCache> unsharded_fec;
-  // allocate output buffers for the tester
-  std::vector<at::Tensor> unsharded_outputs;
-  std::unique_ptr<Fusion> fusion_copy;
-  if (runtime->comm()->deviceId() == tester) {
-    recordEvent("compile unsharded fusion and alloc output");
-    fusion_copy = std::make_unique<Fusion>(*runtime->fusion());
-    unshard(fusion_copy.get());
-    unsharded_fec =
-        std::make_unique<FusionExecutorCache>(std::move(fusion_copy));
-    unsharded_outputs = unsharded_fec->allocOutputSpace(unsharded_inputs);
-  } else {
-    // On non-tester devices, these tensors won't be used.
-    // we copy the local outputs for convenience
-    unsharded_outputs = outputs;
+  recordEvent("validate unsharded fusion");
+  GTEST_ASSERT_EQ(ref_unsharded_outputs.size(), outputs.size());
+  for (int i : c10::irange(runtime->fusion()->outputs().size())) {
+    GTEST_ASSERT_TRUE(runtime->fusion()->outputs().at(i)->isA<TensorView>());
+    auto output_tv = runtime->fusion()->outputs().at(i)->as<TensorView>();
+    if (!output_tv->getDeviceMesh().has(communicator->deviceId())) {
+      continue;
+    }
+    auto ref_output = isSharded(output_tv) ?
+      shardTensor(ref_unsharded_outputs.at(i), output_tv->getDeviceMesh(), communicator->deviceId())
+      : ref_unsharded_outputs.at(i);
+    auto obtained_output = outputs.at(i);
+    GTEST_EXPECT_TRUE(torch::allclose(ref_output, obtained_output)) << "Device " << communicator->deviceId() << " has unexpected output " << i << " corresponding to tv " << output_tv << ". Expected values: " << ref_output << ", obtained values: " << obtained_output;
   }
-
-  recordEvent("gather outputs at tester");
-  // gathering all the outputs at tester
-  for (auto i : c10::irange(outputs.size())) {
-    SendToTester(
-        runtime->fusion()->outputs().at(i)->as<TensorView>(),
-        outputs.at(i),
-        unsharded_outputs.at(i),
-        tester,
-        runtime->comm(),
-        debug_print);
-  }
-
-  if (runtime->comm()->deviceId() == tester) {
-    if (debug_print) {
-      std::stringstream ss;
-      std::string indent = "  ";
-      ss << "Obtained final outputs:{\n";
-      for (auto& t : unsharded_outputs) {
-        ss << indent << t;
-      }
-      ss << "\n}\n";
-      ss << "Reference (unsharded) input:{\n";
-      for (auto& t : unsharded_inputs) {
-        ss << indent << t;
-      }
-      ss << "\n}";
-      std::cout << ss.str() << std::endl;
+  GTEST_ASSERT_EQ(ref_unsharded_outputs.size(), outputs.size());
+  for (int i : c10::irange(runtime->fusion()->outputs().size())) {
+    GTEST_ASSERT_TRUE(runtime->fusion()->outputs().at(i)->isA<TensorView>());
+    auto output_tv = runtime->fusion()->outputs().at(i)->as<TensorView>();
+    if (!output_tv->getDeviceMesh().has(communicator->deviceId())) {
+      continue;
     }
-
-    // execute the fusion on one device without pipeline scheduling
-    std::vector<at::Tensor> ref_outputs;
-    if (auto_schedule) {
-      recordEvent("run unsharded fusion");
-      ref_outputs = unsharded_fec->runFusionWithInputs(unsharded_inputs);
-    } else {
-      recordEvent("compile unsharded fusion");
-      FusionExecutor fe;
-      fe.compileFusion(unsharded_fec->fusion(), unsharded_inputs);
-      recordEvent("run unsharded fusion");
-      ref_outputs = fe.runFusion(unsharded_inputs);
-    }
-
-    if (debug_print) {
-      std::stringstream ss;
-      std::string indent = "  ";
-      ss << "Expected outputs:{\n";
-      for (auto& t : ref_outputs) {
-        ss << indent << t;
-      }
-      ss << "\n}";
-      std::cout << ss.str() << std::endl;
-    }
-
-    recordEvent("validate unsharded fusion");
-    testValidate(
-        unsharded_fec->fusion(),
-        unsharded_outputs,
-        unsharded_inputs,
-        ref_outputs,
-        __LINE__,
-        __FILE__);
+    auto ref_output = shardTensor(ref_unsharded_outputs.at(i), output_tv->getDeviceMesh(), communicator->deviceId());
+    auto obtained_output = outputs.at(i);
+    GTEST_EXPECT_TRUE(torch::allclose(ref_output, obtained_output)) << "Device " << communicator->deviceId() << " has unexpected output " << i <<", expected: " << ref_output << ", obtained: " << obtained_output;
   }
 }
 
 // Run and validate a pipeline
 // with given (possibly sharded) inputs
 void PipelineTest::execute() {
-  if (debug_print && !communicator->deviceId()) {
-    fusion->printKernel();
+
+  GTEST_ASSERT_EQ(unsharded_inputs.size(), fusion->inputs().size());
+  for (int i : c10::irange(fusion->inputs().size())) {
+    GTEST_ASSERT_TRUE(fusion->inputs().at(i)->isA<TensorView>());
+    auto input_tv = fusion->inputs().at(i)->as<TensorView>();
+    auto input = isSharded(input_tv) ? 
+        shardTensor(unsharded_inputs.at(i).toTensor(), input_tv->getDeviceMesh(), communicator->deviceId())
+        : unsharded_inputs.at(i).toTensor();
+    inputs.push_back(input);
+  }
+
+  if (debug_print) {
+    if (!communicator->deviceId()) {
+      fusion->printKernel();
+    }
+    std::stringstream ss;
+    std::string indent = "  ";
+    ss << "Device " << communicator->deviceId() << "'s inputs:{\n";
+    for (auto& t : inputs) {
+      ss << indent << t;
+    }
+    ss << "\n}";
+    std::cout << ss.str() << std::endl;
   }
 
   recordEvent("runtime instantiation");

--- a/test/multidevice.cpp
+++ b/test/multidevice.cpp
@@ -118,14 +118,16 @@ void PipelineTest::validate() {
   // execute the fusion on one device without pipeline scheduling
   auto fusion_copy = std::make_unique<Fusion>(*runtime->fusion());
   unshard(fusion_copy.get());
-  FusionExecutorCache unsharded_fec (std::move(fusion_copy));
+  FusionExecutorCache unsharded_fec(std::move(fusion_copy));
   recordEvent("run unsharded fusion");
-  auto ref_unsharded_outputs = unsharded_fec.runFusionWithInputs(unsharded_inputs);
+  auto ref_unsharded_outputs =
+      unsharded_fec.runFusionWithInputs(unsharded_inputs);
 
   if (debug_print) {
     std::stringstream ss;
     std::string indent = "  ";
-    ss << "Device " << communicator->deviceId() << "'s expected (unsharded) outputs:{\n";
+    ss << "Device " << communicator->deviceId()
+       << "'s expected (unsharded) outputs:{\n";
     for (auto& t : ref_unsharded_outputs) {
       ss << indent << t;
     }
@@ -141,25 +143,32 @@ void PipelineTest::validate() {
     if (!output_tv->getDeviceMesh().has(communicator->deviceId())) {
       continue;
     }
-    auto ref_output = isSharded(output_tv) ?
-      shardTensor(ref_unsharded_outputs.at(i), output_tv->getDeviceMesh(), communicator->deviceId())
-      : ref_unsharded_outputs.at(i);
+    auto ref_output = isSharded(output_tv) ? shardTensor(
+                                                 ref_unsharded_outputs.at(i),
+                                                 output_tv->getDeviceMesh(),
+                                                 communicator->deviceId())
+                                           : ref_unsharded_outputs.at(i);
     auto obtained_output = outputs.at(i);
-    GTEST_EXPECT_TRUE(torch::allclose(ref_output, obtained_output)) << "Device " << communicator->deviceId() << " has unexpected output " << i << " corresponding to tv " << output_tv << ". Expected values: " << ref_output << ", obtained values: " << obtained_output;
+    GTEST_EXPECT_TRUE(torch::allclose(ref_output, obtained_output))
+        << "Device " << communicator->deviceId() << " has unexpected output "
+        << i << " corresponding to tv " << output_tv
+        << ". Expected values: " << ref_output
+        << ", obtained values: " << obtained_output;
   }
 }
 
 // Run and validate a pipeline
 // with given (possibly sharded) inputs
 void PipelineTest::execute() {
-
   GTEST_ASSERT_EQ(unsharded_inputs.size(), fusion->inputs().size());
   for (int i : c10::irange(fusion->inputs().size())) {
     GTEST_ASSERT_TRUE(fusion->inputs().at(i)->isA<TensorView>());
     auto input_tv = fusion->inputs().at(i)->as<TensorView>();
-    auto input = isSharded(input_tv) ? 
-        shardTensor(unsharded_inputs.at(i).toTensor(), input_tv->getDeviceMesh(), communicator->deviceId())
-        : unsharded_inputs.at(i).toTensor();
+    auto input = isSharded(input_tv) ? shardTensor(
+                                           unsharded_inputs.at(i).toTensor(),
+                                           input_tv->getDeviceMesh(),
+                                           communicator->deviceId())
+                                     : unsharded_inputs.at(i).toTensor();
     inputs.push_back(input);
   }
 

--- a/test/multidevice.h
+++ b/test/multidevice.h
@@ -45,18 +45,15 @@ class MultiDeviceEnvironment : public testing::Environment {
 };
 
 class MultiDeviceTest : public NVFuserTest {
- public:
-  static at::Tensor shardInputTensor(
-      at::Tensor tensor,
-      DeviceMesh& mesh,
-      int deviceId) {
+  public:
+  static at::Tensor shardInputTensor(at::Tensor tensor, DeviceMesh& mesh, int deviceId) {
     int i = 0;
     auto devices = mesh.vector();
-    auto it = find(devices.begin(), devices.end(), deviceId);
+    auto it = find (devices.begin(), devices.end(), deviceId);
     if (it != devices.end()) {
-      i = *it;
+      i = std::distance(devices.begin(), it);
     }
-    return tensor.index({at::indexing::Slice(i, i + 1), "..."});
+    return tensor.index({at::indexing::Slice(i, i+1), "..."});
   }
 
  protected:

--- a/test/multidevice.h
+++ b/test/multidevice.h
@@ -91,7 +91,7 @@ class CommunicationTest
 class PipelineTest : public MultiDeviceTest {
  protected:
   void SetUp() override;
-  void validate(DeviceIdxType tester = 0, bool auto_schedule = true);
+  void validate();
   void execute();
   void executeAndValidate() {
     execute();
@@ -100,6 +100,7 @@ class PipelineTest : public MultiDeviceTest {
   std::unique_ptr<MultiDeviceExecutor> runtime;
   std::unique_ptr<Fusion> fusion;
   std::vector<c10::IValue> inputs;
+  std::vector<c10::IValue> unsharded_inputs;
   std::vector<at::Tensor> outputs;
 };
 

--- a/test/multidevice.h
+++ b/test/multidevice.h
@@ -46,7 +46,7 @@ class MultiDeviceEnvironment : public testing::Environment {
 
 class MultiDeviceTest : public NVFuserTest {
   public:
-  static at::Tensor shardInputTensor(at::Tensor tensor, DeviceMesh& mesh, int deviceId) {
+  static at::Tensor shardInputTensor(at::Tensor tensor, const DeviceMesh& mesh, DeviceIdxType deviceId) {
     int i = 0;
     auto devices = mesh.vector();
     auto it = find (devices.begin(), devices.end(), deviceId);

--- a/test/multidevice.h
+++ b/test/multidevice.h
@@ -46,7 +46,7 @@ class MultiDeviceEnvironment : public testing::Environment {
 
 class MultiDeviceTest : public NVFuserTest {
   public:
-  static at::Tensor shardInputTensor(at::Tensor tensor, const DeviceMesh& mesh, DeviceIdxType deviceId) {
+  static at::Tensor shardTensor(at::Tensor tensor, const DeviceMesh& mesh, DeviceIdxType deviceId) {
     int i = 0;
     auto devices = mesh.vector();
     auto it = find (devices.begin(), devices.end(), deviceId);

--- a/test/multidevice.h
+++ b/test/multidevice.h
@@ -45,15 +45,18 @@ class MultiDeviceEnvironment : public testing::Environment {
 };
 
 class MultiDeviceTest : public NVFuserTest {
-  public:
-  static at::Tensor shardTensor(at::Tensor tensor, const DeviceMesh& mesh, DeviceIdxType deviceId) {
+ public:
+  static at::Tensor shardTensor(
+      at::Tensor tensor,
+      const DeviceMesh& mesh,
+      DeviceIdxType deviceId) {
     int i = 0;
     auto devices = mesh.vector();
-    auto it = find (devices.begin(), devices.end(), deviceId);
+    auto it = find(devices.begin(), devices.end(), deviceId);
     if (it != devices.end()) {
       i = std::distance(devices.begin(), it);
     }
-    return tensor.index({at::indexing::Slice(i, i+1), "..."});
+    return tensor.index({at::indexing::Slice(i, i + 1), "..."});
   }
 
  protected:

--- a/test/test_multidevice_pipeline.cpp
+++ b/test/test_multidevice_pipeline.cpp
@@ -124,7 +124,7 @@ TEST_F(PipelineTest, Pipeline) {
   // Create input tensors.
   // Note: each process is binded to a different GPU
   // Note: the concrete values are only used at the relevant ranks
-  inputs = {
+  unsharded_inputs = {
       at::randn(input_shape1, tensor_options),
       at::randn(input_shape2, tensor_options)};
 

--- a/test/test_multidevice_pipeline.cpp
+++ b/test/test_multidevice_pipeline.cpp
@@ -53,8 +53,8 @@ using namespace at::indexing;
 */
 
 TEST_F(PipelineTest, Pipeline) {
-  const std::vector<int64_t> input_shape1 = {6, 7};
-  const std::vector<int64_t> input_shape2 = {3, 5, 2};
+  const std::vector<int64_t> input_shape1 = {3096, 1123};
+  const std::vector<int64_t> input_shape2 = {2048, 73, 81};
   // ===========================================================
   //        FUSION
   // ===========================================================

--- a/test/test_multidevice_pipeline.cpp
+++ b/test/test_multidevice_pipeline.cpp
@@ -53,8 +53,8 @@ using namespace at::indexing;
 */
 
 TEST_F(PipelineTest, Pipeline) {
-  const std::vector<int64_t> input_shape1 = {3096, 1123};
-  const std::vector<int64_t> input_shape2 = {2048, 73, 81};
+  const std::vector<int64_t> input_shape1 = {6, 7};
+  const std::vector<int64_t> input_shape2 = {3, 5, 2};
   // ===========================================================
   //        FUSION
   // ===========================================================

--- a/test/test_multidevice_pipeline.cpp
+++ b/test/test_multidevice_pipeline.cpp
@@ -170,11 +170,7 @@ TEST_P(PipelineTestTwoStages, Communication) {
   }
   std::vector<int64_t> unsharded_input_sizes = {
       first_axis_extent, second_axis_extent, 3, 5};
-  std::vector<int64_t> sharded_input_sizes = unsharded_input_sizes;
-  if (is_stage0_sharded) {
-    sharded_input_sizes[0] = 1;
-  }
-
+  
   FusionGuard fg(fusion.get());
   TensorView* tv0 = makeConcreteTensor(unsharded_input_sizes);
   TensorView* tv1 = sum(tv0, {3});
@@ -199,8 +195,7 @@ TEST_P(PipelineTestTwoStages, Communication) {
     tv3->axis(0)->parallelize(ParallelType::DIDx);
   }
 
-  inputs = {
-      at::ones(sharded_input_sizes, tensor_options) * communicator->deviceId()};
+  unsharded_inputs = {at::randn(unsharded_input_sizes, tensor_options)};
 
   executeAndValidate();
 }
@@ -562,14 +557,11 @@ TEST_F(PipelineTest, matmuls_megatron_mlp) {
   auto aT = at::randn({M, K}, tensor_options);
   auto b = at::randn({M, O}, tensor_options);
   auto myDevice = communicator->deviceId();
-  inputs = {
-      x,
-      shardInputTensor(aT, mesh, myDevice),
-      shardInputTensor(b, mesh, myDevice)};
-  auto y = at::matmul(x, aT.transpose(0, 1));
+  inputs = {x, shardTensor(aT, mesh, myDevice),
+            shardTensor(b, mesh, myDevice)};
+  auto y = at::matmul(x, aT.transpose(0,1));
   auto z = at::matmul(y, b);
-  auto expected_outputs = {
-      shardInputTensor(y.transpose(0, 1), mesh, myDevice), z};
+  auto expected_outputs = {shardTensor(y.transpose(0,1), mesh, myDevice), z};
 
   MultiDeviceExecutor runtime(std::move(fusion), *communicator);
   auto outputs = runtime.runWithInput(inputs);
@@ -657,23 +649,19 @@ TEST_F(PipelineTest, matmul_megatron_attention) {
   auto aten_v = at::randn({H, S, Dv}, tensor_options);
   auto aten_w = at::randn({H, Dv, D_model}, tensor_options);
   auto deviceId = communicator->deviceId();
-  inputs = {
-      shardInputTensor(aten_q, mesh, deviceId),
-      shardInputTensor(aten_k, mesh, deviceId),
-      shardInputTensor(aten_v, mesh, deviceId),
-      shardInputTensor(aten_w, mesh, deviceId)};
-  auto aten_qk = at::matmul(
-      aten_q, aten_k.permute({0, 2, 1})); // H, S, Dk x H, Dk, S -> H, S, S
+  inputs = {shardTensor(aten_q, mesh, deviceId),
+            shardTensor(aten_k, mesh, deviceId),
+            shardTensor(aten_v, mesh, deviceId),
+            shardTensor(aten_w, mesh, deviceId)};
+  auto aten_qk = at::matmul(aten_q, aten_k.permute({0, 2, 1})); // H, S, Dk x H, Dk, S -> H, S, S
   auto aten_qkv = at::matmul(aten_qk, aten_v); // H, S, S x H, S, Dv -> H, S, Dv
-  auto aten_qkv_concat = aten_qkv.permute({1, 0, 2}).flatten(1, 2); // S, H*Dv
-  auto aten_w_ = aten_w.flatten(0, 1); // H*Dv, Dmodel
-  auto out = at::matmul(
-      aten_qkv_concat, aten_w_); // S, H*Dv x H*Dv, Dmodel -> S, Dmodel
-  auto expected_outputs = {
-      shardInputTensor(aten_qk, mesh, deviceId),
-      shardInputTensor(aten_qkv, mesh, deviceId),
-      out};
-
+  auto aten_qkv_concat = aten_qkv.permute({1, 0, 2}).flatten(1, 2); // S, H*Dv 
+  auto aten_w_ = aten_w.flatten(0, 1); // H*Dv, Dmodel 
+  auto out = at::matmul(aten_qkv_concat, aten_w_); // S, H*Dv x H*Dv, Dmodel -> S, Dmodel
+  auto expected_outputs = {shardTensor(aten_qk, mesh, deviceId),
+                           shardTensor(aten_qkv, mesh, deviceId),
+                           out};
+  
   MultiDeviceExecutor runtime(std::move(fusion), *communicator);
   auto outputs = runtime.runWithInput(inputs);
   testValidate(

--- a/test/test_multidevice_sharding.cpp
+++ b/test/test_multidevice_sharding.cpp
@@ -85,7 +85,7 @@ TEST_F(ShardingTest, ShardGlobalInput) {
 
   auto x = at::randn(unsharded_input_size, tensor_options);
   std::vector<c10::IValue> inputs = {
-      shardInputTensor(x, mesh, communicator->deviceId())};
+      shardTensor(x, mesh, communicator->deviceId())};
   auto ref_outputs = x * 2;
 
   MultiDeviceExecutor runtime(std::move(fusion), *communicator);


### PR DESCRIPTION
Simplify the tests utility by testing locally at each rank. Slight speed-up of the tests.
The main but reasonable drawback is that each rank must have the full input available for testing.